### PR TITLE
fix: inherit node from parent process and set NODE_OPTIONS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# Command Reference
+
+## Build and Test Commands
+
+To verify the code compiles and the tests pass, run:
+
+```bash
+go run ./cmd/cdktf-provider-gen/ -c ./example.yml -cdktf-version 0.20.7 
+```
+
+You can use `-keep` flag to keep the generated code for furthur inspection:
+
+```bash
+SRC_LOG_LEVEL=debug go run ./cmd/cdktf-provider-gen/ -c ./example.yml -cdktf-version 0.20.7 -keep
+```
+
+You can find the directory from logs. Remember to delete the directory after inspection to save disk space.
+
+# Code Standards and Conventions
+
+- Use `github.com/sourcegraph/run` for running external commands.
+- Use `github.com/sourcegraph/log` for logging.
+- Use `github.com/sourcegraph/sourcegraph/lib/errors` for error handling.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/cmd/cdktf-provider-gen/main.go
+++ b/cmd/cdktf-provider-gen/main.go
@@ -106,17 +106,15 @@ cdktf-provider-gen -config google.yaml -cdktf-version 0.17.3
 		// the subprocess cwd. Shim-based version managers (asdf, etc.) resolve
 		// node based on the cwd's .tool-versions, so without this the subprocess
 		// running in tmpDir would fall back to a different node than the parent.
-		nodeBinDir, err := resolveNodeBinDir(c.Context)
+		nodeEnv, err := resolveNodeEnv(c.Context)
 		if err != nil {
-			return errors.Wrap(err, "resolve node bin dir")
+			return errors.Wrap(err, "resolve node env")
 		}
-		logger = logger.With(log.String("node.binDir", nodeBinDir))
-		_ = os.Setenv("PATH", nodeBinDir+string(os.PathListSeparator)+os.Getenv("PATH"))
-		nodeVersion, err := run.Cmd(c.Context, "node", "--version").Run().String()
-		if err != nil {
-			return errors.Wrap(err, "get node version")
-		}
-		logger = logger.With(log.String("node.version", strings.TrimSpace(nodeVersion)))
+		logger = logger.With(
+			log.String("node.binDir", nodeEnv.binDir),
+			log.String("node.version", nodeEnv.version),
+		)
+		_ = os.Setenv("PATH", nodeEnv.binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 		b, err := os.ReadFile(configFlag.Get(c))
 		if err != nil {
@@ -256,21 +254,33 @@ cdktf-provider-gen -config google.yaml -cdktf-version 0.17.3
 	},
 }
 
-// resolveNodeBinDir asks node where its real binary lives (process.execPath)
-// and returns the containing directory. This works for any install layout
+type nodeEnv struct {
+	binDir  string
+	version string
+}
+
+// resolveNodeEnv asks node where its real binary lives (process.execPath) and
+// reports its version. Using process.execPath works for any install layout
 // (asdf/nvm/fnm/volta/brew/system) because node reports its own absolute path
 // even when invoked via a version-manager shim. npm is colocated with node in
 // all common layouts.
-func resolveNodeBinDir(ctx context.Context) (string, error) {
+func resolveNodeEnv(ctx context.Context) (nodeEnv, error) {
 	out, err := run.Cmd(ctx, "node", "-e", "process.stdout.write(process.execPath)").Run().String()
 	if err != nil {
-		return "", errors.Wrap(err, "exec node to resolve execPath")
+		return nodeEnv{}, errors.Wrap(err, "exec node to resolve execPath")
 	}
 	execPath := strings.TrimSpace(out)
 	if execPath == "" {
-		return "", errors.New("node returned empty execPath")
+		return nodeEnv{}, errors.New("node returned empty execPath")
 	}
-	return filepath.Dir(execPath), nil
+	version, err := run.Cmd(ctx, execPath, "--version").Run().String()
+	if err != nil {
+		return nodeEnv{}, errors.Wrap(err, "get node version")
+	}
+	return nodeEnv{
+		binDir:  filepath.Dir(execPath),
+		version: strings.TrimSpace(version),
+	}, nil
 }
 
 func Last[E any](s []E) (E, bool) {

--- a/cmd/cdktf-provider-gen/main.go
+++ b/cmd/cdktf-provider-gen/main.go
@@ -49,6 +49,10 @@ var (
 	packageJSONTemplate       = template.Must(template.New("").Parse(packageJSONTemplateString))
 )
 
+const (
+	defaultNodeOptions = "--max-old-space-size=8192"
+)
+
 type projectTemplateData struct {
 	Config      generator.Config
 	PackageName string
@@ -97,6 +101,23 @@ cdktf-provider-gen -config google.yaml -cdktf-version 0.17.3
 		}
 		_ = os.Setenv("PATH", tfInstallDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
+		// Resolve node's real bin directory from the parent process's cwd and
+		// prepend it to PATH so subprocesses use the same node/npm regardless of
+		// the subprocess cwd. Shim-based version managers (asdf, etc.) resolve
+		// node based on the cwd's .tool-versions, so without this the subprocess
+		// running in tmpDir would fall back to a different node than the parent.
+		nodeBinDir, err := resolveNodeBinDir(c.Context)
+		if err != nil {
+			return errors.Wrap(err, "resolve node bin dir")
+		}
+		logger = logger.With(log.String("node.binDir", nodeBinDir))
+		_ = os.Setenv("PATH", nodeBinDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+		nodeVersion, err := run.Cmd(c.Context, "node", "--version").Run().String()
+		if err != nil {
+			return errors.Wrap(err, "get node version")
+		}
+		logger = logger.With(log.String("node.version", strings.TrimSpace(nodeVersion)))
+
 		b, err := os.ReadFile(configFlag.Get(c))
 		if err != nil {
 			return errors.Wrap(err, "read config file")
@@ -109,8 +130,8 @@ cdktf-provider-gen -config google.yaml -cdktf-version 0.17.3
 		logger = logger.With(log.String("name", config.Name))
 		if config.Provider != nil {
 			logger = logger.With(
-				log.String("name", config.Name),
 				log.String("provider.name", config.Provider.Name),
+				log.String("provider.source", config.Provider.Source),
 				log.String("provider.version", config.Provider.Version),
 			)
 		}
@@ -195,7 +216,11 @@ cdktf-provider-gen -config google.yaml -cdktf-version 0.17.3
 			"rm -rf ./src", // remove the source code dir `./src`, we only need `./lib`, shave off a few extra bytes
 			"npm run pkg:go",
 		} {
-			if err := run.Cmd(cmdCtx, cmd).Dir(tmpDir).Run().Wait(); err != nil {
+			runner := run.Cmd(cmdCtx, cmd).Dir(tmpDir).Environ(os.Environ())
+			if os.Getenv("NODE_OPTIONS") == "" {
+				runner = runner.Env(map[string]string{"NODE_OPTIONS": defaultNodeOptions})
+			}
+			if err := runner.Run().Wait(); err != nil {
 				return errors.Wrapf(err, "run: %q", cmd)
 			}
 		}
@@ -229,6 +254,23 @@ cdktf-provider-gen -config google.yaml -cdktf-version 0.17.3
 
 		return nil
 	},
+}
+
+// resolveNodeBinDir asks node where its real binary lives (process.execPath)
+// and returns the containing directory. This works for any install layout
+// (asdf/nvm/fnm/volta/brew/system) because node reports its own absolute path
+// even when invoked via a version-manager shim. npm is colocated with node in
+// all common layouts.
+func resolveNodeBinDir(ctx context.Context) (string, error) {
+	out, err := run.Cmd(ctx, "node", "-e", "process.stdout.write(process.execPath)").Run().String()
+	if err != nil {
+		return "", errors.Wrap(err, "exec node to resolve execPath")
+	}
+	execPath := strings.TrimSpace(out)
+	if execPath == "" {
+		return "", errors.New("node returned empty execPath")
+	}
+	return filepath.Dir(execPath), nil
 }
 
 func Last[E any](s []E) (E, bool) {

--- a/example.yml
+++ b/example.yml
@@ -1,0 +1,11 @@
+name: tls
+
+provider:
+  source: registry.terraform.io/hashicorp/tls
+  version: "4.0.4"
+
+target:
+  language: go
+  moduleName: github.com/sourcegraph/controller-cdktf/gen
+
+output: gen


### PR DESCRIPTION
## Summary
- Resolve node's real bin directory via `process.execPath` and prepend it to `PATH` so subprocesses use the same node/npm as the parent, fixing shim-based version managers (asdf, etc.) that would otherwise resolve a different node based on `tmpDir`'s `.tool-versions` (or the system wide node version).
- Default `NODE_OPTIONS=--max-old-space-size=8192` for the `npm`/`pkg:go` subprocesses (unless already set) to avoid OOMs, and log `node.binDir`, `node.version`, and `provider.source` for easier debugging.
- Add `AGENTS.md` (with a `CLAUDE.md` symlink) documenting the build/test command and code conventions, plus a minimal `example.yml` using the tls provider.

## Test plan
- [x] `go run ./cmd/cdktf-provider-gen/ -c ./example.yml -cdktf-version 0.20.7` exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)